### PR TITLE
Fix summary accuracy and save correct answers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { QuizMode, TermTag, QuizResult } from './types';
 import { useStats } from './hooks/useStats';
-import { useQuiz } from './hooks/useQuiz';
 import { Home } from './pages/Home';
 import { Quiz } from './pages/Quiz';
 import { Summary } from './pages/Summary';
@@ -16,7 +15,7 @@ function App() {
   const [selectedTags, setSelectedTags] = useState<TermTag[]>([]);
   const [quizResults, setQuizResults] = useState<QuizResult[]>([]);
   
-  const { stats, getStrugglingTerms, resetAllStats } = useStats();
+  const { getStrugglingTerms, resetAllStats } = useStats();
   const strugglingTermIds = getStrugglingTerms();
 
   const handleStartQuiz = (mode: QuizMode, tags: TermTag[] = []) => {
@@ -25,7 +24,8 @@ function App() {
     setAppState('quiz');
   };
 
-  const handleQuizComplete = () => {
+  const handleQuizComplete = (results: QuizResult[]) => {
+    setQuizResults(results);
     setAppState('summary');
   };
 

--- a/src/pages/Quiz.tsx
+++ b/src/pages/Quiz.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
-import { QuizMode, TermTag } from '../types';
+import { QuizMode, TermTag, QuizResult } from '../types';
 import { useQuiz } from '../hooks/useQuiz';
 import { useStats } from '../hooks/useStats';
+import { addCorrectTerm } from '../utils/storage';
 import { QuizCard } from '../components/QuizCard';
 import { FeedbackCard } from '../components/FeedbackCard';
 import { Progress } from '../components/Progress';
@@ -12,7 +13,7 @@ interface QuizProps {
   selectedTags?: TermTag[];
   strugglingTermIds: string[];
   onBack: () => void;
-  onComplete: () => void;
+  onComplete: (results: QuizResult[]) => void;
 }
 
 export const Quiz: React.FC<QuizProps> = ({
@@ -33,7 +34,8 @@ export const Quiz: React.FC<QuizProps> = ({
     submitAnswer,
     nextQuestion,
     getCurrentQuestion,
-    getProgress
+    getProgress,
+    getResults
   } = useQuiz(mode, selectedTags, strugglingTermIds);
 
   const question = getCurrentQuestion();
@@ -41,17 +43,20 @@ export const Quiz: React.FC<QuizProps> = ({
 
   const handleAnswerSelect = (answerIndex: number) => {
     if (!question || showFeedback) return;
-    
+
     submitAnswer(answerIndex);
-    
+
     // Update stats
     const isCorrect = answerIndex === question.correctIndex;
     updateStats(question.term.id, isCorrect);
+    if (isCorrect) {
+      addCorrectTerm(question.term.id);
+    }
   };
 
   const handleNext = () => {
     if (isCompleted) {
-      onComplete();
+      onComplete(getResults());
     } else {
       nextQuestion();
       setShowDetailedExplanation(false);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,6 +1,7 @@
 import { TermStats } from '../types';
 
 const STORAGE_KEY = 'math-quiz-stats-v1';
+const CORRECT_TERMS_KEY = 'math-quiz-correct-terms-v1';
 
 export const loadStats = (): Record<string, TermStats> => {
   try {
@@ -25,6 +26,28 @@ export const resetStats = (): void => {
     localStorage.removeItem(STORAGE_KEY);
   } catch (error) {
     console.error('Failed to reset stats:', error);
+  }
+};
+
+export const loadCorrectTerms = (): string[] => {
+  try {
+    const stored = localStorage.getItem(CORRECT_TERMS_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch (error) {
+    console.error('Failed to load correct terms:', error);
+    return [];
+  }
+};
+
+export const addCorrectTerm = (termId: string): void => {
+  try {
+    const terms = loadCorrectTerms();
+    if (!terms.includes(termId)) {
+      terms.push(termId);
+      localStorage.setItem(CORRECT_TERMS_KEY, JSON.stringify(terms));
+    }
+  } catch (error) {
+    console.error('Failed to save correct term:', error);
   }
 };
 


### PR DESCRIPTION
## Summary
- ensure quiz results are passed to `Summary` to avoid NaN accuracy
- track correct term IDs in localStorage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687791feb9748325ac7a63c532c87d69